### PR TITLE
Use NVIDIA archive URL instead of Github

### DIFF
--- a/nvidia-persistenced.spec
+++ b/nvidia-persistenced.spec
@@ -7,7 +7,7 @@ License:        GPLv2+
 URL:            http://www.nvidia.com/object/unix.html
 ExclusiveArch:  %{ix86} x86_64
 
-Source0:        https://github.com/NVIDIA/%{name}/archive/%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source0:        https://download.nvidia.com/XFree86/%{name}/%{name}-%{version}.tar.bz2
 Source1:        %{name}.service
 Source2:        %{name}.init
 


### PR DESCRIPTION
Github seems to lag a bit behind on releases of open NVIDIA tools. For example, 396.18 is not yet available on any of their repos, but is present on the official archive.